### PR TITLE
Use system language by default

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LocaleHelper.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LocaleHelper.kt
@@ -9,11 +9,12 @@ object LocaleHelper {
      * Returns the currently saved language code from SharedPreferences.
      *
      * @param context Context used to access SharedPreferences.
-     * @return String Language code (e.g., "en", "es"). Defaults to "en" if not set.
+     * @return String Language code (e.g., "en", "es"). Defaults to system language if not set.
      */
     fun getLanguage(context: Context): String {
         val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
-        return prefs.getString("language", "en") ?: "en"
+        val saved = prefs.getString("language", null)
+        return saved ?: Locale.getDefault().language
     }
 
     /**

--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/SettingsActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/SettingsActivity.kt
@@ -58,8 +58,7 @@ class SettingsActivity : BaseActivity() {
     private fun showLanguageDialog() {
         val languages = arrayOf(getString(R.string.english), getString(R.string.spanish))
         val codes = arrayOf("en", "es")
-        val prefs = getSharedPreferences("settings", MODE_PRIVATE)
-        val current = prefs.getString("language", "en")
+        val current = LocaleHelper.getLanguage(this)
         val checked = if (current == "es") 1 else 0
         AlertDialog.Builder(this)
             .setTitle(R.string.language)


### PR DESCRIPTION
## Summary
- default to device locale if no language is stored
- use LocaleHelper in settings dialog to show current language

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893c19f14e08333ae39f75f14b65d29