### PR TITLE
Add Portuguese, Italian, German and French translations

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/SettingsActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/SettingsActivity.kt
@@ -56,10 +56,17 @@ class SettingsActivity : BaseActivity() {
     }
 
     private fun showLanguageDialog() {
-        val languages = arrayOf(getString(R.string.english), getString(R.string.spanish))
-        val codes = arrayOf("en", "es")
+        val languages = arrayOf(
+            getString(R.string.english),
+            getString(R.string.spanish),
+            getString(R.string.portuguese),
+            getString(R.string.italian),
+            getString(R.string.german),
+            getString(R.string.french)
+        )
+        val codes = arrayOf("en", "es", "pt", "it", "de", "fr")
         val current = LocaleHelper.getLanguage(this)
-        val checked = if (current == "es") 1 else 0
+        val checked = codes.indexOf(current).let { if (it >= 0) it else 0 }
         AlertDialog.Builder(this)
             .setTitle(R.string.language)
             .setSingleChoiceItems(languages, checked) { dialog, which ->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,52 @@
+<resources>
+    <string name="app_name">Geburtstagserinnerung</string>
+    <string name="test_app">Geburtstage prüfen</string>
+    <string name="open_json">Geburtstage ändern</string>
+    <string name="settings">Einstellungen</string>
+    <string name="set_time">Benachrichtigungszeit festlegen</string>
+    <string name="logout">Abmelden</string>
+    <string name="add_birthday">Geburtstag hinzufügen</string>
+    <string name="birthday_list_title">Geburtstage</string>
+    <string name="login">Anmelden</string>
+    <string name="linkedin">Mein LinkedIn</string>
+    <string name="buy_me_coffee">Spendier mir einen Kaffee</string>
+    <string name="repo">Dieses Repository</string>
+    <string name="no_birthdays">\uD83D\uDD6F Heute keine Geburtstage</string>
+    <string name="birthdays_today"><![CDATA[<b>Geburtstage heute:</b><br>%1$s<br>Benachrichtigungen prüfen<br>]]></string>
+    <string name="birthday_today"><![CDATA[<b>Geburtstag heute:</b><br>%1$s<br>Benachrichtigungen prüfen<br>]]></string>
+    <string name="language">Sprache</string>
+    <string name="english">Englisch</string>
+    <string name="spanish">Spanisch</string>
+    <string name="portuguese">Portugiesisch</string>
+    <string name="italian">Italienisch</string>
+    <string name="german">Deutsch</string>
+    <string name="french">Französisch</string>
+    <string name="login_failed">Anmeldung fehlgeschlagen: %1$s</string>
+    <string name="auth_failed">Authentifizierung fehlgeschlagen: %1$s</string>
+    <string name="hint_name">Name</string>
+    <string name="hint_date">Datum (dd-mm)</string>
+    <string name="hint_phone">Telefon</string>
+    <string name="hint_message">Geburtstagsgruß</string>
+    <string name="import_contact">Importieren</string>
+    <string name="filter_name">Namen filtern</string>
+    <string-array name="sort_options">
+        <item>Datum asc</item>
+        <item>Datum desc</item>
+        <item>Name asc</item>
+        <item>Name desc</item>
+    </string-array>
+    <string name="edit_birthday">Geburtstag bearbeiten</string>
+    <string name="save">Speichern</string>
+    <string name="delete">Löschen</string>
+    <string name="confirm_delete">Löschen bestätigen</string>
+    <string name="are_you_sure">Bist du sicher?</string>
+    <string name="yes">Ja</string>
+    <string name="no">Nein</string>
+    <string name="cancel">Abbrechen</string>
+    <string name="permission_required">Berechtigung erforderlich, um Kontakt zu importieren</string>
+    <string name="birthday_item">%1$s - %2$s</string>
+    <string name="default_message">Alles Gute zum Geburtstag, %1$s! 🎉🥳</string>
+    <string name="notification_channel_name">Geburtstage</string>
+    <string name="notification_title">Geburtstag von %1$s</string>
+    <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -17,6 +17,10 @@
     <string name="language">Idioma</string>
     <string name="english">Inglés</string>
     <string name="spanish">Español</string>
+    <string name="portuguese">Portugués</string>
+    <string name="italian">Italiano</string>
+    <string name="german">Alemán</string>
+    <string name="french">Francés</string>
     <string name="login_failed">Error de inicio: %1$s</string>
     <string name="auth_failed">Autenticación fallida: %1$s</string>
     <string name="hint_name">Nombre</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,52 @@
+<resources>
+    <string name="app_name">Rappel Anniversaire</string>
+    <string name="test_app">Vérifier les anniversaires</string>
+    <string name="open_json">Modifier les anniversaires</string>
+    <string name="settings">Paramètres</string>
+    <string name="set_time">Définir l'heure de notification</string>
+    <string name="logout">Se déconnecter</string>
+    <string name="add_birthday">Ajouter un anniversaire</string>
+    <string name="birthday_list_title">Anniversaires</string>
+    <string name="login">Se connecter</string>
+    <string name="linkedin">Mon LinkedIn</string>
+    <string name="buy_me_coffee">Offrez-moi un café</string>
+    <string name="repo">Ce dépôt</string>
+    <string name="no_birthdays">\uD83D\uDD6F Aucun anniversaire aujourd'hui</string>
+    <string name="birthdays_today"><![CDATA[<b>Anniversaires aujourd'hui :</b><br>%1$s<br>Vérifiez les notifications<br>]]></string>
+    <string name="birthday_today"><![CDATA[<b>Anniversaire aujourd'hui :</b><br>%1$s<br>Vérifiez les notifications<br>]]></string>
+    <string name="language">Langue</string>
+    <string name="english">Anglais</string>
+    <string name="spanish">Espagnol</string>
+    <string name="portuguese">Portugais</string>
+    <string name="italian">Italien</string>
+    <string name="german">Allemand</string>
+    <string name="french">Français</string>
+    <string name="login_failed">Échec de connexion : %1$s</string>
+    <string name="auth_failed">Échec d'authentification : %1$s</string>
+    <string name="hint_name">Nom</string>
+    <string name="hint_date">Date (jj-mm)</string>
+    <string name="hint_phone">Téléphone</string>
+    <string name="hint_message">Message d'anniversaire</string>
+    <string name="import_contact">Importer</string>
+    <string name="filter_name">Filtrer le nom</string>
+    <string-array name="sort_options">
+        <item>Date asc</item>
+        <item>Date desc</item>
+        <item>Nom asc</item>
+        <item>Nom desc</item>
+    </string-array>
+    <string name="edit_birthday">Modifier l'anniversaire</string>
+    <string name="save">Enregistrer</string>
+    <string name="delete">Supprimer</string>
+    <string name="confirm_delete">Confirmer la suppression</string>
+    <string name="are_you_sure">Vous êtes sûr ?</string>
+    <string name="yes">Oui</string>
+    <string name="no">Non</string>
+    <string name="cancel">Annuler</string>
+    <string name="permission_required">Permission requise pour importer le contact</string>
+    <string name="birthday_item">%1$s - %2$s</string>
+    <string name="default_message">Joyeux anniversaire, %1$s ! 🎉🥳</string>
+    <string name="notification_channel_name">Anniversaires</string>
+    <string name="notification_title">Anniversaire de %1$s</string>
+    <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,52 @@
+<resources>
+    <string name="app_name">Promemoria Compleanni</string>
+    <string name="test_app">Controlla compleanni</string>
+    <string name="open_json">Modifica compleanni</string>
+    <string name="settings">Impostazioni</string>
+    <string name="set_time">Imposta orario della notifica</string>
+    <string name="logout">Disconnetti</string>
+    <string name="add_birthday">Aggiungi compleanno</string>
+    <string name="birthday_list_title">Compleanni</string>
+    <string name="login">Accedi</string>
+    <string name="linkedin">Il mio LinkedIn</string>
+    <string name="buy_me_coffee">Offrimi un caffè</string>
+    <string name="repo">Questo repository</string>
+    <string name="no_birthdays">\uD83D\uDD6F Nessun compleanno oggi</string>
+    <string name="birthdays_today"><![CDATA[<b>Compleanni di oggi:</b><br>%1$s<br>Controlla le notifiche<br>]]></string>
+    <string name="birthday_today"><![CDATA[<b>Compleanno di oggi:</b><br>%1$s<br>Controlla le notifiche<br>]]></string>
+    <string name="language">Lingua</string>
+    <string name="english">Inglese</string>
+    <string name="spanish">Spagnolo</string>
+    <string name="portuguese">Portoghese</string>
+    <string name="italian">Italiano</string>
+    <string name="german">Tedesco</string>
+    <string name="french">Francese</string>
+    <string name="login_failed">Accesso fallito: %1$s</string>
+    <string name="auth_failed">Autenticazione fallita: %1$s</string>
+    <string name="hint_name">Nome</string>
+    <string name="hint_date">Data (dd-mm)</string>
+    <string name="hint_phone">Telefono</string>
+    <string name="hint_message">Messaggio di auguri</string>
+    <string name="import_contact">Importa</string>
+    <string name="filter_name">Filtra nome</string>
+    <string-array name="sort_options">
+        <item>Data asc</item>
+        <item>Data desc</item>
+        <item>Nome asc</item>
+        <item>Nome desc</item>
+    </string-array>
+    <string name="edit_birthday">Modifica compleanno</string>
+    <string name="save">Salva</string>
+    <string name="delete">Elimina</string>
+    <string name="confirm_delete">Conferma eliminazione</string>
+    <string name="are_you_sure">Sei sicuro?</string>
+    <string name="yes">Sì</string>
+    <string name="no">No</string>
+    <string name="cancel">Annulla</string>
+    <string name="permission_required">Permesso necessario per importare contatto</string>
+    <string name="birthday_item">%1$s - %2$s</string>
+    <string name="default_message">Tanti auguri, %1$s! 🎉🥳</string>
+    <string name="notification_channel_name">Compleanni</string>
+    <string name="notification_title">Compleanno di %1$s</string>
+    <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
+</resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,0 +1,52 @@
+<resources>
+    <string name="app_name">Lembrete de Aniversário</string>
+    <string name="test_app">Verificar aniversários</string>
+    <string name="open_json">Alterar aniversários</string>
+    <string name="settings">Configurações</string>
+    <string name="set_time">Definir horário da notificação</string>
+    <string name="logout">Sair</string>
+    <string name="add_birthday">Adicionar aniversário</string>
+    <string name="birthday_list_title">Aniversários</string>
+    <string name="login">Entrar</string>
+    <string name="linkedin">Meu LinkedIn</string>
+    <string name="buy_me_coffee">Me pague um café</string>
+    <string name="repo">Este repositório</string>
+    <string name="no_birthdays">\uD83D\uDD6F Nenhum aniversário hoje</string>
+    <string name="birthdays_today"><![CDATA[<b>Aniversários hoje:</b><br>%1$s<br>Confira as notificações<br>]]></string>
+    <string name="birthday_today"><![CDATA[<b>Aniversário hoje:</b><br>%1$s<br>Confira as notificações<br>]]></string>
+    <string name="language">Idioma</string>
+    <string name="english">Inglês</string>
+    <string name="spanish">Espanhol</string>
+    <string name="portuguese">Português</string>
+    <string name="italian">Italiano</string>
+    <string name="german">Alemão</string>
+    <string name="french">Francês</string>
+    <string name="login_failed">Falha ao entrar: %1$s</string>
+    <string name="auth_failed">Falha de autenticação: %1$s</string>
+    <string name="hint_name">Nome</string>
+    <string name="hint_date">Data (dd-mm)</string>
+    <string name="hint_phone">Telefone</string>
+    <string name="hint_message">Mensagem de parabéns</string>
+    <string name="import_contact">Importar</string>
+    <string name="filter_name">Filtrar nome</string>
+    <string-array name="sort_options">
+        <item>Data asc</item>
+        <item>Data desc</item>
+        <item>Nome asc</item>
+        <item>Nome desc</item>
+    </string-array>
+    <string name="edit_birthday">Editar aniversário</string>
+    <string name="save">Salvar</string>
+    <string name="delete">Excluir</string>
+    <string name="confirm_delete">Confirmar exclusão</string>
+    <string name="are_you_sure">Tem certeza?</string>
+    <string name="yes">Sim</string>
+    <string name="no">Não</string>
+    <string name="cancel">Cancelar</string>
+    <string name="permission_required">Permissão necessária para importar contato</string>
+    <string name="birthday_item">%1$s - %2$s</string>
+    <string name="default_message">Parabéns, %1$s! 🎉🥳</string>
+    <string name="notification_channel_name">Aniversários</string>
+    <string name="notification_title">Aniversário de %1$s</string>
+    <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,10 @@
     <string name="language">Language</string>
     <string name="english">English</string>
     <string name="spanish">Espa\u00f1ol</string>
+    <string name="portuguese">Portuguese</string>
+    <string name="italian">Italian</string>
+    <string name="german">German</string>
+    <string name="french">French</string>
     <string name="login_failed">Login failed: %1$s</string>
     <string name="auth_failed">Auth failed: %1$s</string>
     <string name="hint_name">Name</string>


### PR DESCRIPTION
## Summary
- Add locale options for Portuguese, Italian, German and French in settings
- Provide resource files with localized UI text and birthday greetings for new languages
- Include language names in English and Spanish resources

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893c3b07c8483338d68ba83e282bf57