### PR TITLE
Add data deletion option with double confirmation

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -41,8 +41,18 @@
         android:backgroundTint="@color/md_theme_light_primary"
         android:text="@string/language"
         android:textColor="@color/md_theme_light_onPrimary" />
-		
-	<com.google.android.material.button.MaterialButton
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonDeleteData"
+        style="?attr/materialButtonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="96dp"
+        android:layout_marginTop="16dp"
+        android:backgroundTint="@color/md_theme_light_primary"
+        android:text="@string/delete_data"
+        android:textColor="@color/md_theme_light_onPrimary" />
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonLogout"
         style="?attr/materialButtonStyle"
         android:layout_width="match_parent"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -49,4 +49,10 @@
     <string name="notification_channel_name">Geburtstage</string>
     <string name="notification_title">Geburtstag von %1$s</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
+    <string name="delete_data">Daten löschen</string>
+    <string name="delete_data_confirm">Alle Daten löschen?</string>
+    <string name="delete_data_type_phrase">Gib "%1$s" ein, um zu bestätigen:</string>
+    <string name="delete_data_phrase">Ich bestätige, dass ich meine Daten löschen möchte</string>
+    <string name="delete_data_done">Alle Daten wurden gelöscht</string>
+    <string name="delete_data_incorrect">Falscher Bestätigungstext</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -49,4 +49,10 @@
     <string name="notification_channel_name">Cumpleaños</string>
     <string name="notification_title">Cumple de %1$s</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
+    <string name="delete_data">Borrar datos</string>
+    <string name="delete_data_confirm">¿Borrar todos los datos?</string>
+    <string name="delete_data_type_phrase">Escribe "%1$s" para confirmar:</string>
+    <string name="delete_data_phrase">confirmo que quiero borrar mis datos</string>
+    <string name="delete_data_done">Todos los datos han sido borrados</string>
+    <string name="delete_data_incorrect">Texto de confirmación incorrecto</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -49,4 +49,10 @@
     <string name="notification_channel_name">Anniversaires</string>
     <string name="notification_title">Anniversaire de %1$s</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
+    <string name="delete_data">Supprimer les données</string>
+    <string name="delete_data_confirm">Supprimer toutes les données ?</string>
+    <string name="delete_data_type_phrase">Tapez "%1$s" pour confirmer :</string>
+    <string name="delete_data_phrase">Je confirme que je souhaite supprimer mes données</string>
+    <string name="delete_data_done">Toutes les données ont été supprimées</string>
+    <string name="delete_data_incorrect">Texte de confirmation incorrect</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -49,4 +49,10 @@
     <string name="notification_channel_name">Compleanni</string>
     <string name="notification_title">Compleanno di %1$s</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
+    <string name="delete_data">Elimina dati</string>
+    <string name="delete_data_confirm">Eliminare tutti i dati?</string>
+    <string name="delete_data_type_phrase">Digita "%1$s" per confermare:</string>
+    <string name="delete_data_phrase">confermo che voglio cancellare i miei dati</string>
+    <string name="delete_data_done">Tutti i dati sono stati eliminati</string>
+    <string name="delete_data_incorrect">Testo di conferma errato</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -49,4 +49,10 @@
     <string name="notification_channel_name">Aniversários</string>
     <string name="notification_title">Aniversário de %1$s</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
+    <string name="delete_data">Apagar dados</string>
+    <string name="delete_data_confirm">Apagar todos os dados?</string>
+    <string name="delete_data_type_phrase">Digite "%1$s" para confirmar:</string>
+    <string name="delete_data_phrase">confirmo que quero apagar meus dados</string>
+    <string name="delete_data_done">Todos os dados foram apagados</string>
+    <string name="delete_data_incorrect">Texto de confirmação incorreto</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,10 @@
     <string name="notification_channel_name">Birthdays</string>
     <string name="notification_title">Birthday: %1$s</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
+    <string name="delete_data">Delete data</string>
+    <string name="delete_data_confirm">Delete all data?</string>
+    <string name="delete_data_type_phrase">Type "%1$s" to confirm:</string>
+    <string name="delete_data_phrase">I confirm I want to delete my data</string>
+    <string name="delete_data_done">All data deleted</string>
+    <string name="delete_data_incorrect">Incorrect confirmation text</string>
 </resources>


### PR DESCRIPTION
## Summary
- add "Delete data" button in settings
- require double confirmation including typed phrase to delete all data
- provide translations for new text in English, Spanish, Portuguese, Italian, German, and French

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893d67c54a48333820ed33b0f4ce3c2