### PR TITLE
Clarify data deletion confirmation prompt

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -51,7 +51,7 @@
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Daten löschen</string>
     <string name="delete_data_confirm">Alle Daten löschen?</string>
-    <string name="delete_data_type_phrase">Gib "%1$s" ein, um zu bestätigen:</string>
+    <string name="delete_data_type_phrase"><![CDATA[Gib ein:<br><b><u>"%1$s"</u></b><br>um zu bestätigen:<br>]]></string>
     <string name="delete_data_phrase">Ich bestätige, dass ich meine Daten löschen möchte</string>
     <string name="delete_data_done">Alle Daten wurden gelöscht</string>
     <string name="delete_data_incorrect">Falscher Bestätigungstext</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -51,8 +51,8 @@
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Borrar datos</string>
     <string name="delete_data_confirm">¿Borrar todos los datos?</string>
-    <string name="delete_data_type_phrase">Escribe "<b><u>%1$s</u></b>" para confirmar:</string>
-    <string name="delete_data_phrase">confirmo que quiero borrar mis datos</string>
+    <string name="delete_data_type_phrase"><![CDATA[Escribe:<br><b><u>"%1$s"</u></b><br>Para confirmar:<br>]]></string>
+    <string name="delete_data_phrase">Confirmo que quiero borrar mis datos</string>
     <string name="delete_data_done">Todos los datos han sido borrados</string>
     <string name="delete_data_incorrect">Texto de confirmación incorrecto</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -51,7 +51,7 @@
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Supprimer les données</string>
     <string name="delete_data_confirm">Supprimer toutes les données ?</string>
-    <string name="delete_data_type_phrase">Tapez "<b><u>%1$s</u></b>" pour confirmer :</string>
+    <string name="delete_data_type_phrase"><![CDATA[Tapez :<br><b><u>"%1$s"</u></b><br>Pour confirmer :<br>]]></string>
     <string name="delete_data_phrase">Je confirme que je souhaite supprimer mes données</string>
     <string name="delete_data_done">Toutes les données ont été supprimées</string>
     <string name="delete_data_incorrect">Texte de confirmation incorrect</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -51,8 +51,8 @@
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Elimina dati</string>
     <string name="delete_data_confirm">Eliminare tutti i dati?</string>
-    <string name="delete_data_type_phrase">Digita "%1$s" per confermare:</string>
-    <string name="delete_data_phrase">confermo che voglio cancellare i miei dati</string>
+    <string name="delete_data_type_phrase"><![CDATA[Digita:<br><b><u>"%1$s"</u></b><br>Per confermare:<br>]]></string>
+    <string name="delete_data_phrase">Confermo che voglio cancellare i miei dati</string>
     <string name="delete_data_done">Tutti i dati sono stati eliminati</string>
     <string name="delete_data_incorrect">Testo di conferma errato</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -51,8 +51,8 @@
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Apagar dados</string>
     <string name="delete_data_confirm">Apagar todos os dados?</string>
-    <string name="delete_data_type_phrase">Digite "<b><u>%1$s</u></b>" para confirmar:</string>
-    <string name="delete_data_phrase">confirmo que quero apagar meus dados</string>
+    <string name="delete_data_type_phrase"><![CDATA[Digite:<br><b><u>"%1$s"</u></b><br>Para confirmar:<br>]]></string>
+    <string name="delete_data_phrase">Confirmo que quero apagar meus dados</string>
     <string name="delete_data_done">Todos os dados foram apagados</string>
     <string name="delete_data_incorrect">Texto de confirmação incorreto</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Delete data</string>
     <string name="delete_data_confirm">Delete all data?</string>
-    <string name="delete_data_type_phrase">Type "<b><u>%1$s</u></b>" to confirm:</string>
+    <string name="delete_data_type_phrase"><![CDATA[Type:<br><b><u>"%1$s"</u></b><br>to confirm:<br>]]></string>
     <string name="delete_data_phrase">I confirm I want to delete my data</string>
     <string name="delete_data_done">All data deleted</string>
     <string name="delete_data_incorrect">Incorrect confirmation text</string>


### PR DESCRIPTION
## Summary
- Reformat deletion confirmation prompt to use line breaks and show the required phrase in bold and underlined text
- Capitalize the confirmation phrase across translations for consistency

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893dfbb91808333959d32df1e3dd80a