### PR TITLE
Add theme switcher

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BaseActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BaseActivity.kt
@@ -1,7 +1,9 @@
 package com.jlianes.birthdaynotifier.presentation
 
 import android.content.Context
+import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
 
 /**
  * Base activity that applies the persisted locale to the context and
@@ -24,6 +26,20 @@ open class BaseActivity : AppCompatActivity() {
     override fun attachBaseContext(newBase: Context) {
         currentLanguage = LocaleHelper.getLanguage(newBase)
         super.attachBaseContext(LocaleHelper.applyBaseContext(newBase))
+    }
+
+    /**
+     * Applies the selected theme before creating the activity.
+     */
+    override fun onCreate(savedInstanceState: Bundle?) {
+        val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+        val mode = when (prefs.getString("theme", "system")) {
+            "light" -> AppCompatDelegate.MODE_NIGHT_NO
+            "dark" -> AppCompatDelegate.MODE_NIGHT_YES
+            else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        }
+        AppCompatDelegate.setDefaultNightMode(mode)
+        super.onCreate(savedInstanceState)
     }
 
     /**

--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/SettingsActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/SettingsActivity.kt
@@ -8,6 +8,7 @@ import android.widget.EditText
 import android.widget.Toast
 import androidx.core.text.HtmlCompat
 import androidx.lifecycle.lifecycleScope
+import androidx.appcompat.app.AppCompatDelegate
 import com.jlianes.birthdaynotifier.R
 import com.jlianes.birthdaynotifier.databinding.ActivitySettingsBinding
 import com.jlianes.birthdaynotifier.framework.cloud.BirthdayFirestoreStorage
@@ -35,6 +36,7 @@ class SettingsActivity : BaseActivity() {
 
         binding.buttonSetTime.setOnClickListener { showTimePicker() }
         binding.buttonLanguage.setOnClickListener { showLanguageDialog() }
+        binding.buttonTheme.setOnClickListener { showThemeDialog() }
         binding.buttonDeleteData.setOnClickListener { confirmDeleteData() }
         binding.buttonLogout.setOnClickListener { performLogout() }
     }
@@ -84,6 +86,32 @@ class SettingsActivity : BaseActivity() {
             .show()
     }
 
+    private fun showThemeDialog() {
+        val themes = arrayOf(
+            getString(R.string.light),
+            getString(R.string.dark),
+            getString(R.string.system_default)
+        )
+        val codes = arrayOf("light", "dark", "system")
+        val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+        val current = prefs.getString("theme", "system")
+        val checked = codes.indexOf(current).let { if (it >= 0) it else 2 }
+        AlertDialog.Builder(this)
+            .setTitle(R.string.theme)
+            .setSingleChoiceItems(themes, checked) { dialog, which ->
+                prefs.edit().putString("theme", codes[which]).apply()
+                val mode = when (codes[which]) {
+                    "light" -> AppCompatDelegate.MODE_NIGHT_NO
+                    "dark" -> AppCompatDelegate.MODE_NIGHT_YES
+                    else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                }
+                AppCompatDelegate.setDefaultNightMode(mode)
+                dialog.dismiss()
+                recreate()
+            }
+            .show()
+    }
+
     private fun confirmDeleteData() {
         AlertDialog.Builder(this)
             .setTitle(R.string.delete_data)
@@ -120,3 +148,4 @@ class SettingsActivity : BaseActivity() {
             .show()
     }
 }
+

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -5,7 +5,7 @@
     android:padding="16dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/md_theme_light_primaryContainer">
+    android:background="?attr/colorPrimaryContainer">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
@@ -28,8 +28,8 @@
         android:layout_height="96dp"
         android:text="@string/set_time"
         style="?attr/materialButtonStyle"
-        android:backgroundTint="@color/md_theme_light_primary"
-        android:textColor="@color/md_theme_light_onPrimary"
+        android:backgroundTint="?attr/colorPrimary"
+        android:textColor="?attr/colorOnPrimary"
         android:layout_marginTop="24dp" />
 
     <com.google.android.material.button.MaterialButton
@@ -38,9 +38,19 @@
         android:layout_width="match_parent"
         android:layout_height="96dp"
         android:layout_marginTop="16dp"
-        android:backgroundTint="@color/md_theme_light_primary"
+        android:backgroundTint="?attr/colorPrimary"
         android:text="@string/language"
-        android:textColor="@color/md_theme_light_onPrimary" />
+        android:textColor="?attr/colorOnPrimary" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonTheme"
+        style="?attr/materialButtonStyle"
+        android:layout_width="match_parent"
+        android:layout_height="96dp"
+        android:layout_marginTop="16dp"
+        android:backgroundTint="?attr/colorPrimary"
+        android:text="@string/theme"
+        android:textColor="?attr/colorOnPrimary" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonDeleteData"
@@ -48,9 +58,9 @@
         android:layout_width="match_parent"
         android:layout_height="96dp"
         android:layout_marginTop="16dp"
-        android:backgroundTint="@color/md_theme_light_primary"
+        android:backgroundTint="?attr/colorPrimary"
         android:text="@string/delete_data"
-        android:textColor="@color/md_theme_light_onPrimary" />
+        android:textColor="?attr/colorOnPrimary" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonLogout"
@@ -58,8 +68,9 @@
         android:layout_width="match_parent"
         android:layout_height="96dp"
         android:layout_marginTop="16dp"
-        android:backgroundTint="@color/md_theme_light_primary"
+        android:backgroundTint="?attr/colorPrimary"
         android:text="@string/logout"
-        android:textColor="@color/md_theme_light_onPrimary" />
+        android:textColor="?attr/colorOnPrimary" />
 
 </LinearLayout>
+

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -55,4 +55,9 @@
     <string name="delete_data_phrase">Ich bestätige, dass ich meine Daten löschen möchte</string>
     <string name="delete_data_done">Alle Daten wurden gelöscht</string>
     <string name="delete_data_incorrect">Falscher Bestätigungstext</string>
+    <string name="theme">Thema</string>
+    <string name="light">Hell</string>
+    <string name="dark">Dunkel</string>
+    <string name="system_default">Systemstandard</string>
 </resources>
+

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,4 +55,9 @@
     <string name="delete_data_phrase">Confirmo que quiero borrar mis datos</string>
     <string name="delete_data_done">Todos los datos han sido borrados</string>
     <string name="delete_data_incorrect">Texto de confirmación incorrecto</string>
+    <string name="theme">Tema</string>
+    <string name="light">Claro</string>
+    <string name="dark">Oscuro</string>
+    <string name="system_default">Predeterminado del sistema</string>
 </resources>
+

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -55,4 +55,9 @@
     <string name="delete_data_phrase">Je confirme que je souhaite supprimer mes données</string>
     <string name="delete_data_done">Toutes les données ont été supprimées</string>
     <string name="delete_data_incorrect">Texte de confirmation incorrect</string>
+    <string name="theme">Thème</string>
+    <string name="light">Clair</string>
+    <string name="dark">Sombre</string>
+    <string name="system_default">Par défaut du système</string>
 </resources>
+

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -55,4 +55,9 @@
     <string name="delete_data_phrase">Confermo che voglio cancellare i miei dati</string>
     <string name="delete_data_done">Tutti i dati sono stati eliminati</string>
     <string name="delete_data_incorrect">Testo di conferma errato</string>
+    <string name="theme">Tema</string>
+    <string name="light">Chiaro</string>
+    <string name="dark">Scuro</string>
+    <string name="system_default">Predefinito di sistema</string>
 </resources>
+

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,15 @@
+<resources>
+    <color name="md_theme_light_primary">#C5CAE9</color>
+    <color name="md_theme_light_onPrimary">#1A237E</color>
+    <color name="md_theme_light_primaryContainer">#3949AB</color>
+    <color name="md_theme_light_onPrimaryContainer">#FFFFFF</color>
+
+    <color name="md_theme_light_secondary">#E8DEF8</color>
+    <color name="md_theme_light_onSecondary">#1D192B</color>
+    <color name="md_theme_light_secondaryContainer">#625B71</color>
+    <color name="md_theme_light_onSecondaryContainer">#FFFFFF</color>
+
+    <color name="md_theme_light_background">#121212</color>
+    <color name="md_theme_light_onBackground">#FFFFFF</color>
+</resources>
+

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -55,4 +55,9 @@
     <string name="delete_data_phrase">Confirmo que quero apagar meus dados</string>
     <string name="delete_data_done">Todos os dados foram apagados</string>
     <string name="delete_data_incorrect">Texto de confirmação incorreto</string>
+    <string name="theme">Tema</string>
+    <string name="light">Claro</string>
+    <string name="dark">Escuro</string>
+    <string name="system_default">Padrão do sistema</string>
 </resources>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,4 +55,9 @@
     <string name="delete_data_phrase">I confirm I want to delete my data</string>
     <string name="delete_data_done">All data deleted</string>
     <string name="delete_data_incorrect">Incorrect confirmation text</string>
+    <string name="theme">Theme</string>
+    <string name="light">Light</string>
+    <string name="dark">Dark</string>
+    <string name="system_default">System default</string>
 </resources>
+


### PR DESCRIPTION
## Summary
- add theme selector dialog to settings
- persist user theme choice and apply on startup
- support dark mode colors

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893e48c1b4c8333979c9ec4c21e0b31