### PR TITLE
Integrate Compose add button and center icon

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,11 @@ android {
 
     buildFeatures {
         viewBinding true
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.9'
     }
 
     compileOptions {
@@ -30,9 +35,9 @@ android {
     }
 }
 
-dependencies {
-    implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'com.google.android.material:material:1.11.0'
+    dependencies {
+        implementation 'androidx.appcompat:appcompat:1.7.1'
+        implementation 'com.google.android.material:material:1.11.0'
 
     implementation "com.google.android.gms:play-services-auth:21.2.0"
     implementation("com.google.firebase:firebase-auth:22.3.0")
@@ -45,5 +50,12 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.0")
     implementation 'org.json:json:20230618'
     implementation 'com.googlecode.libphonenumber:libphonenumber:8.13.21'
-    implementation 'com.hbb20:ccp:2.7.3'
-}
+        implementation 'com.hbb20:ccp:2.7.3'
+
+        implementation platform('androidx.compose:compose-bom:2024.04.01')
+        implementation 'androidx.activity:activity-compose:1.9.0'
+        implementation 'androidx.compose.ui:ui'
+        implementation 'androidx.compose.material3:material3'
+        implementation 'androidx.compose.ui:ui-tooling-preview'
+        debugImplementation 'androidx.compose.ui:ui-tooling'
+    }

--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayListActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayListActivity.kt
@@ -14,6 +14,12 @@ import android.text.InputType
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.widget.addTextChangedListener
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.colorResource
 import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.hbb20.CountryCodePicker
 import com.jlianes.birthdaynotifier.R
@@ -111,8 +117,17 @@ class BirthdayListActivity : BaseActivity() {
             showEditDialog(originalIndex, helper.get(originalIndex))
         }
 
-        binding.buttonAdd.setOnClickListener {
-            showEditDialog(-1, null)
+        binding.buttonAdd.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                FloatingActionButton(
+                    onClick = { showEditDialog(-1, null) },
+                    containerColor = colorResource(R.color.md_theme_light_primary),
+                    contentColor = colorResource(R.color.md_theme_light_onPrimary)
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = getString(R.string.add_birthday))
+                }
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_birthday_list.xml
+++ b/app/src/main/res/layout/activity_birthday_list.xml
@@ -51,18 +51,12 @@
         android:layout_below="@id/filterLayout"
         android:layout_above="@id/buttonAdd" />
 
-    <com.google.android.material.button.MaterialButton
+    <androidx.compose.ui.platform.ComposeView
         android:id="@+id/buttonAdd"
         android:layout_width="56dp"
         android:layout_height="56dp"
         android:layout_alignParentEnd="true"
         android:layout_alignParentBottom="true"
-        android:layout_margin="16dp"
-        style="?attr/materialButtonStyle"
-        android:backgroundTint="@color/md_theme_light_primary"
-        app:icon="@android:drawable/ic_input_add"
-        app:iconTint="@color/md_theme_light_onPrimary"
-        app:cornerRadius="0dp"
-        android:padding="0dp" />
+        android:layout_margin="16dp" />
 
 </RelativeLayout>


### PR DESCRIPTION
## Summary
- enable Jetpack Compose in Gradle and add core Compose dependencies
- render the add-birthday action with a Compose FloatingActionButton for a cleaner look
- ensure the plus icon is centered via Compose

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894b8588b5083338426ad36e0bae66e