### PR TITLE
Improve interaction feedback and dark mode styling

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayListActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayListActivity.kt
@@ -20,8 +20,17 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.colorResource
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.hbb20.CountryCodePicker
+import com.google.android.material.button.MaterialButton
 import com.jlianes.birthdaynotifier.R
 import java.util.Calendar
 import java.util.Locale
@@ -120,10 +129,19 @@ class BirthdayListActivity : BaseActivity() {
         binding.buttonAdd.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
+                val interaction = remember { MutableInteractionSource() }
+                val pressed by interaction.collectIsPressedAsState()
+                val scale by animateFloatAsState(if (pressed) 0.9f else 1f, label = "fabScale")
+                val container by animateColorAsState(
+                    targetValue = if (pressed) colorResource(R.color.md_theme_light_primaryContainer) else colorResource(R.color.md_theme_light_primary),
+                    label = "fabColor"
+                )
                 FloatingActionButton(
                     onClick = { showEditDialog(-1, null) },
-                    containerColor = colorResource(R.color.md_theme_light_primary),
-                    contentColor = colorResource(R.color.md_theme_light_onPrimary)
+                    containerColor = container,
+                    contentColor = colorResource(R.color.md_theme_light_onPrimary),
+                    interactionSource = interaction,
+                    modifier = Modifier.scale(scale)
                 ) {
                     Icon(Icons.Default.Add, contentDescription = getString(R.string.add_birthday))
                 }
@@ -218,6 +236,12 @@ class BirthdayListActivity : BaseActivity() {
         }
         val messageInput = EditText(this).apply { hint = getString(R.string.hint_message) }
 
+        val textColor = ContextCompat.getColor(this, R.color.md_theme_light_onBackground)
+        listOf(nameInput, dateInput, phoneInput, messageInput).forEach {
+            it.setTextColor(textColor)
+            it.setHintTextColor(textColor)
+        }
+
         obj?.let {
             nameInput.setText(it.getString("name"))
             dateInput.setText(it.getString("date"))
@@ -225,7 +249,18 @@ class BirthdayListActivity : BaseActivity() {
             messageInput.setText(it.optString("message"))
         }
 
-        val importButton = Button(this).apply { text = getString(R.string.import_contact) }
+        val importButton = MaterialButton(this).apply {
+            text = getString(R.string.import_contact)
+            backgroundTintList = ContextCompat.getColorStateList(
+                this@BirthdayListActivity,
+                R.color.md_theme_light_primary
+            )
+            setTextColor(ContextCompat.getColor(this@BirthdayListActivity, R.color.md_theme_light_onPrimary))
+            rippleColor = ContextCompat.getColorStateList(
+                this@BirthdayListActivity,
+                R.color.md_theme_light_primaryContainer
+            )
+        }
         val dialogLayout = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(50, 40, 50, 10)

--- a/app/src/main/res/layout/activity_birthday_list.xml
+++ b/app/src/main/res/layout/activity_birthday_list.xml
@@ -40,8 +40,8 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:hint="@string/filter_name"
-            android:textColor="@android:color/black"
-            android:textColorHint="@android:color/black" />
+            android:textColor="@color/md_theme_light_onBackground"
+            android:textColorHint="@color/md_theme_light_onBackground" />
     </LinearLayout>
 
     <ListView
@@ -49,7 +49,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@id/filterLayout"
-        android:layout_above="@id/buttonAdd" />
+        android:layout_above="@id/buttonAdd"
+        android:listSelector="?attr/selectableItemBackground" />
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/buttonAdd"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -5,7 +5,8 @@
     android:gravity="center"
     android:padding="16dp"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/md_theme_light_primaryContainer">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
@@ -31,6 +32,7 @@
         android:backgroundTint="@color/md_theme_light_primary"
         android:textColor="@color/md_theme_light_onPrimary"
         android:layout_marginTop="48dp"
-        app:cornerRadius="0dp" />
+        app:cornerRadius="16dp"
+        app:rippleColor="@color/md_theme_light_primaryContainer" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,7 +31,8 @@
         android:backgroundTint="@color/md_theme_light_primary"
         android:textColor="@color/md_theme_light_onPrimary"
         android:layout_marginTop="24dp"
-        app:cornerRadius="0dp" />
+        app:cornerRadius="16dp"
+        app:rippleColor="@color/md_theme_light_primaryContainer" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonOpen"
@@ -42,7 +43,8 @@
         android:backgroundTint="@color/md_theme_light_primary"
         android:text="@string/open_json"
         android:textColor="@color/md_theme_light_onPrimary"
-        app:cornerRadius="0dp" />
+        app:cornerRadius="16dp"
+        app:rippleColor="@color/md_theme_light_primaryContainer" />
 
     <TextView
         android:id="@+id/textStatus"
@@ -66,7 +68,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:background="@null"
+                        android:background="?attr/selectableItemBackgroundBorderless"
                         android:src="@drawable/ic_linkedin"
                         android:contentDescription="@string/linkedin" />
 
@@ -75,7 +77,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:background="@null"
+                        android:background="?attr/selectableItemBackgroundBorderless"
                         android:src="@drawable/ic_buymeacoffee"
                         android:contentDescription="@string/buy_me_coffee" />
 
@@ -84,7 +86,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:background="@null"
+                        android:background="?attr/selectableItemBackgroundBorderless"
                         android:src="@drawable/ic_github"
                         android:contentDescription="@string/repo" />
 
@@ -93,7 +95,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:background="@null"
+                        android:background="?attr/selectableItemBackgroundBorderless"
                         android:src="@drawable/ic_settings"
                         android:contentDescription="@string/settings" />
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -31,7 +31,8 @@
         android:backgroundTint="?attr/colorPrimary"
         android:textColor="?attr/colorOnPrimary"
         android:layout_marginTop="24dp"
-        app:cornerRadius="0dp" />
+        app:cornerRadius="16dp"
+        app:rippleColor="@color/md_theme_light_primaryContainer" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonLanguage"
@@ -42,7 +43,8 @@
         android:backgroundTint="?attr/colorPrimary"
         android:text="@string/language"
         android:textColor="?attr/colorOnPrimary"
-        app:cornerRadius="0dp" />
+        app:cornerRadius="16dp"
+        app:rippleColor="@color/md_theme_light_primaryContainer" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonTheme"
@@ -53,7 +55,8 @@
         android:backgroundTint="?attr/colorPrimary"
         android:text="@string/theme"
         android:textColor="?attr/colorOnPrimary"
-        app:cornerRadius="0dp" />
+        app:cornerRadius="16dp"
+        app:rippleColor="@color/md_theme_light_primaryContainer" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonDeleteData"
@@ -64,7 +67,8 @@
         android:backgroundTint="?attr/colorPrimary"
         android:text="@string/delete_data"
         android:textColor="?attr/colorOnPrimary"
-        app:cornerRadius="0dp" />
+        app:cornerRadius="16dp"
+        app:rippleColor="@color/md_theme_light_primaryContainer" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonLogout"
@@ -75,7 +79,8 @@
         android:backgroundTint="?attr/colorPrimary"
         android:text="@string/logout"
         android:textColor="?attr/colorOnPrimary"
-        app:cornerRadius="0dp" />
+        app:cornerRadius="16dp"
+        app:rippleColor="@color/md_theme_light_primaryContainer" />
 
 </LinearLayout>
 

--- a/app/src/main/res/layout/item_birthday.xml
+++ b/app/src/main/res/layout/item_birthday.xml
@@ -4,8 +4,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
+    android:foreground="?attr/selectableItemBackground"
+    android:clickable="true"
     app:cardElevation="4dp"
-    app:cardCornerRadius="0dp"
+    app:cardCornerRadius="16dp"
     app:cardBackgroundColor="@color/md_theme_light_primary">
 
     <LinearLayout

--- a/app/src/main/res/layout/spinner_item.xml
+++ b/app/src/main/res/layout/spinner_item.xml
@@ -3,4 +3,4 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="8dp"
-    android:textColor="@android:color/black" />
+    android:textColor="@color/md_theme_light_onBackground" />

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -10,5 +10,6 @@
         <item name="colorOnSecondaryContainer">@color/md_theme_light_onSecondaryContainer</item>
         <item name="android:colorBackground">@color/md_theme_light_background</item>
         <item name="colorOnBackground">@color/md_theme_light_onBackground</item>
+        <item name="android:colorControlHighlight">@color/md_theme_light_primaryContainer</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- Round Material buttons and add ripple feedback across screens
- Animate add-birthday FAB with scale and color changes on press
- Ensure text fields and list items use theme colors in dark mode

## Testing
- `./gradlew test` *(fails: Unable to initialize main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6894bc4050048333aa5b38fbb551e275