### PR TITLE
Make birthday list the main screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,9 +20,6 @@
         <!-- Settings screen -->
         <activity android:name=".presentation.SettingsActivity" />
 
-        <!-- Main screen after login -->
-        <activity android:name=".presentation.MainActivity" />
-
         <!-- Login screen -->
         <activity android:name=".presentation.LoginActivity"
             android:exported="true">

--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LoginActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LoginActivity.kt
@@ -94,7 +94,7 @@ class LoginActivity : BaseActivity() {
      * Navigates to the main activity and finishes the login screen.
      */
     private fun goToMain() {
-        startActivity(Intent(this, MainActivity::class.java))
+        startActivity(Intent(this, BirthdayListActivity::class.java))
         finish()
     }
 }

--- a/app/src/main/res/drawable/ic_add.xml
+++ b/app/src/main/res/drawable/ic_add.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,13H13v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19l12-12-1.41-1.41z"/>
+</vector>

--- a/app/src/main/res/layout/activity_birthday_list.xml
+++ b/app/src/main/res/layout/activity_birthday_list.xml
@@ -11,12 +11,32 @@
         android:layout_height="wrap_content"
         android:backgroundTint="?attr/colorPrimary">
 
+        <ImageButton
+            android:id="@+id/buttonTest"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_check"
+            android:tint="@color/md_theme_light_onPrimary"
+            android:contentDescription="@string/test_app" />
+
         <ImageView
             android:layout_width="@dimen/logo_size"
             android:layout_height="@dimen/logo_size"
             android:layout_gravity="center"
             android:src="@drawable/ic_cake"
             android:contentDescription="@string/app_name" />
+
+        <ImageButton
+            android:id="@+id/buttonAdd"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:background="@android:color/transparent"
+            android:src="@drawable/ic_add"
+            android:tint="@color/md_theme_light_onPrimary"
+            android:contentDescription="@string/add_birthday" />
 
     </com.google.android.material.appbar.MaterialToolbar>
 
@@ -49,15 +69,64 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@id/filterLayout"
-        android:layout_above="@id/buttonAdd"
+        android:layout_above="@id/textStatus"
         android:listSelector="?attr/selectableItemBackground" />
 
-    <androidx.compose.ui.platform.ComposeView
-        android:id="@+id/buttonAdd"
-        android:layout_width="56dp"
-        android:layout_height="56dp"
-        android:layout_alignParentEnd="true"
+    <TextView
+        android:id="@+id/textStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/bottomBar"
+        android:gravity="center"
+        android:textColor="@color/md_theme_light_primary"
+        android:textStyle="bold"
+        android:textSize="24sp"
+        android:visibility="gone" />
+
+    <LinearLayout
+        android:id="@+id/bottomBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:layout_margin="16dp" />
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <ImageButton
+            android:id="@+id/buttonLinkedin"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_linkedin"
+            android:contentDescription="@string/linkedin" />
+
+        <ImageButton
+            android:id="@+id/buttonCoffee"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_buymeacoffee"
+            android:contentDescription="@string/buy_me_coffee" />
+
+        <ImageButton
+            android:id="@+id/buttonRepo"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_github"
+            android:contentDescription="@string/repo" />
+
+        <ImageButton
+            android:id="@+id/buttonSettingsIcon"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_settings"
+            android:contentDescription="@string/settings" />
+
+    </LinearLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
## Summary
- Make birthday list editor the landing screen with check and add buttons on the toolbar
- Add bottom action bar and manual birthday check logic
- Start birthday list directly after login and remove obsolete MainActivity

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894c18951948333aefd8f35c0cf902f