### PR TITLE
Refactor birthday check buttons with Compose

### DIFF
--- a/app/src/main/res/layout/activity_birthday_list.xml
+++ b/app/src/main/res/layout/activity_birthday_list.xml
@@ -11,32 +11,12 @@
         android:layout_height="wrap_content"
         android:backgroundTint="?attr/colorPrimary">
 
-        <ImageButton
-            android:id="@+id/buttonTest"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start"
-            android:background="@android:color/transparent"
-            android:src="@drawable/ic_check"
-            android:tint="@color/md_theme_light_onPrimary"
-            android:contentDescription="@string/test_app" />
-
         <ImageView
             android:layout_width="@dimen/logo_size"
             android:layout_height="@dimen/logo_size"
             android:layout_gravity="center"
             android:src="@drawable/ic_cake"
             android:contentDescription="@string/app_name" />
-
-        <ImageButton
-            android:id="@+id/buttonAdd"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:background="@android:color/transparent"
-            android:src="@drawable/ic_add"
-            android:tint="@color/md_theme_light_onPrimary"
-            android:contentDescription="@string/add_birthday" />
 
     </com.google.android.material.appbar.MaterialToolbar>
 
@@ -76,18 +56,26 @@
         android:id="@+id/textStatus"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_above="@id/bottomBar"
+        android:layout_above="@id/floatingButtons"
         android:gravity="center"
         android:textColor="@color/md_theme_light_primary"
         android:textStyle="bold"
         android:textSize="24sp"
         android:visibility="gone" />
 
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/floatingButtons"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/bottomBar"
+        android:padding="8dp" />
+
     <LinearLayout
         android:id="@+id/bottomBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
+        android:layout_marginBottom="16dp"
         android:orientation="horizontal"
         android:gravity="center">
 
@@ -128,5 +116,21 @@
             android:contentDescription="@string/settings" />
 
     </LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/checkOverlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/md_theme_light_primaryContainer"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/checking_birthdays"
+            android:textColor="@color/md_theme_light_primary"
+            android:textSize="24sp" />
+    </FrameLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -59,5 +59,6 @@
     <string name="light">Hell</string>
     <string name="dark">Dunkel</string>
     <string name="system_default">Systemstandard</string>
+    <string name="checking_birthdays">Überprüfung…</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -59,5 +59,6 @@
     <string name="light">Claro</string>
     <string name="dark">Oscuro</string>
     <string name="system_default">Predeterminado del sistema</string>
+    <string name="checking_birthdays">Comprobando…</string>
 </resources>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -59,5 +59,6 @@
     <string name="light">Clair</string>
     <string name="dark">Sombre</string>
     <string name="system_default">Par défaut du système</string>
+    <string name="checking_birthdays">Vérification…</string>
 </resources>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -59,5 +59,6 @@
     <string name="light">Chiaro</string>
     <string name="dark">Scuro</string>
     <string name="system_default">Predefinito di sistema</string>
+    <string name="checking_birthdays">Verifica…</string>
 </resources>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -59,5 +59,6 @@
     <string name="light">Claro</string>
     <string name="dark">Escuro</string>
     <string name="system_default">Padrão do sistema</string>
+    <string name="checking_birthdays">Verificando…</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,5 +59,6 @@
     <string name="light">Light</string>
     <string name="dark">Dark</string>
     <string name="system_default">System default</string>
+    <string name="checking_birthdays">Checking…</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- move manual check and add buttons into a Compose row above the settings bar with square borders
- show temporary overlay when running birthday check
- adjust bottom bar spacing and add string resources for overlay message

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894c9d792f083339664fe7cf097a631