### PR TITLE
Improve dark theme icon visibility

### DIFF
--- a/app/src/main/res/layout/activity_birthday_list.xml
+++ b/app/src/main/res/layout/activity_birthday_list.xml
@@ -78,6 +78,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:src="@drawable/ic_linkedin"
+            android:tint="?attr/colorOnBackground"
             android:contentDescription="@string/linkedin" />
 
         <ImageButton
@@ -87,6 +88,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:src="@drawable/ic_buymeacoffee"
+            android:tint="?attr/colorOnBackground"
             android:contentDescription="@string/buy_me_coffee" />
 
         <ImageButton
@@ -96,6 +98,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:src="@drawable/ic_github"
+            android:tint="?attr/colorOnBackground"
             android:contentDescription="@string/repo" />
 
         <ImageButton
@@ -105,6 +108,7 @@
             android:layout_weight="1"
             android:background="?attr/selectableItemBackgroundBorderless"
             android:src="@drawable/ic_settings"
+            android:tint="?attr/colorOnBackground"
             android:contentDescription="@string/settings" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -70,6 +70,7 @@
                         android:layout_weight="1"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:src="@drawable/ic_linkedin"
+                        android:tint="?attr/colorOnBackground"
                         android:contentDescription="@string/linkedin" />
 
                 <ImageButton
@@ -79,6 +80,7 @@
                         android:layout_weight="1"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:src="@drawable/ic_buymeacoffee"
+                        android:tint="?attr/colorOnBackground"
                         android:contentDescription="@string/buy_me_coffee" />
 
                 <ImageButton
@@ -88,6 +90,7 @@
                         android:layout_weight="1"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:src="@drawable/ic_github"
+                        android:tint="?attr/colorOnBackground"
                         android:contentDescription="@string/repo" />
 
                 <ImageButton
@@ -97,6 +100,7 @@
                         android:layout_weight="1"
                         android:background="?attr/selectableItemBackgroundBorderless"
                         android:src="@drawable/ic_settings"
+                        android:tint="?attr/colorOnBackground"
                         android:contentDescription="@string/settings" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -18,6 +18,7 @@
             android:layout_height="@dimen/logo_size"
             android:layout_gravity="center"
             android:src="@drawable/ic_cake"
+            android:tint="@android:color/white"
             android:contentDescription="@string/app_name" />
 
     </com.google.android.material.appbar.MaterialToolbar>


### PR DESCRIPTION
## Summary
- tint bottom navigation icons with `colorOnBackground` for better contrast in dark mode
- show white logo in settings toolbar to keep it visible on dark backgrounds

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d8bc4a1883338c969502d6e59cc3