### PR TITLE
Ensure cake icon visible in dark mode

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -12,13 +12,14 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:backgroundTint="?attr/colorPrimary">
+        android:background="?attr/colorPrimary">
 
         <ImageView
             android:layout_width="@dimen/logo_size"
             android:layout_height="@dimen/logo_size"
             android:layout_gravity="center"
             android:src="@drawable/ic_cake"
+            android:tint="?attr/colorOnPrimary"
             android:contentDescription="@string/app_name" />
 
     </com.google.android.material.appbar.MaterialToolbar>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,13 +11,14 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:backgroundTint="?attr/colorPrimary">
+        android:background="?attr/colorPrimary">
 
         <ImageView
             android:layout_width="@dimen/logo_size"
             android:layout_height="@dimen/logo_size"
             android:layout_gravity="center"
             android:src="@drawable/ic_cake"
+            android:tint="?attr/colorOnPrimary"
             android:contentDescription="@string/app_name" />
 
     </com.google.android.material.appbar.MaterialToolbar>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -11,14 +11,14 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:backgroundTint="?attr/colorPrimary">
+        android:background="?attr/colorPrimary">
 
         <ImageView
             android:layout_width="@dimen/logo_size"
             android:layout_height="@dimen/logo_size"
             android:layout_gravity="center"
             android:src="@drawable/ic_cake"
-            android:tint="@android:color/white"
+            android:tint="?attr/colorOnPrimary"
             android:contentDescription="@string/app_name" />
 
     </com.google.android.material.appbar.MaterialToolbar>


### PR DESCRIPTION
## Summary
- Tint cake icon using `colorOnPrimary` so it contrasts with the toolbar background across login, main and settings screens
- Use `android:background` for each toolbar to correctly apply the primary color

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6894db5bf25c83339247f60e5108fa22