### PR TITLE
Use Material buttons and add calendar icon

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayListActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayListActivity.kt
@@ -21,18 +21,14 @@ import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import androidx.core.widget.addTextChangedListener
 import androidx.annotation.StringRes
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.google.android.material.button.MaterialButton
 import com.google.i18n.phonenumbers.PhoneNumberUtil
@@ -454,26 +450,23 @@ private fun FloatingButtonRow(onCheck: () -> Unit, onAdd: () -> Unit) {
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceEvenly
     ) {
-        SquareTextButton(R.string.manual_check, onCheck)
-        SquareTextButton(R.string.add_contact, onAdd)
+        ClassicButton(R.string.manual_check, onCheck)
+        ClassicButton(R.string.add_contact, onAdd)
     }
 }
 
 @Composable
-private fun SquareTextButton(@StringRes textRes: Int, onClick: () -> Unit) {
-    val color = if (isSystemInDarkTheme()) Color.White else MaterialTheme.colorScheme.primary
-    Box(
+private fun ClassicButton(@StringRes textRes: Int, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
         modifier = Modifier
-            .width(120.dp)
-            .height(60.dp)
-            .border(2.dp, color)
-            .clickable { onClick() },
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = stringResource(id = textRes),
-            color = color,
-            textAlign = TextAlign.Center
+            .width(160.dp)
+            .height(48.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary
         )
+    ) {
+        Text(text = stringResource(id = textRes))
     }
 }

--- a/app/src/main/res/drawable/ic_calendar.xml
+++ b/app/src/main/res/drawable/ic_calendar.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,4h-1V2h-2v2H8V2H6v2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V6c0,-1.1 -0.9,-2 -2,-2zM19,20H5V9h14v11zm0,-13H5V6h14v1z" />
+</vector>

--- a/app/src/main/res/layout/item_birthday.xml
+++ b/app/src/main/res/layout/item_birthday.xml
@@ -25,12 +25,27 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <TextView
-            android:id="@+id/textDate"
-            android:textColor="?attr/colorOnSurface"
-            android:textSize="14sp"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:src="@drawable/ic_calendar"
+                android:tint="?attr/colorOnSurface"
+                android:contentDescription="@string/calendar_icon_desc" />
+
+            <TextView
+                android:id="@+id/textDate"
+                android:layout_marginStart="4dp"
+                android:textColor="?attr/colorOnSurface"
+                android:textSize="14sp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
 
         <TextView
             android:id="@+id/textMessage"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -62,5 +62,6 @@
     <string name="checking_birthdays">Überprüfung…</string>
     <string name="manual_check">Manuelle Prüfung</string>
     <string name="add_contact">Kontakt hinzufügen</string>
+    <string name="calendar_icon_desc">Kalendersymbol</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -62,5 +62,6 @@
     <string name="checking_birthdays">Comprobando…</string>
     <string name="manual_check">Revisión manual</string>
     <string name="add_contact">Añadir contacto</string>
+    <string name="calendar_icon_desc">Icono de calendario</string>
 </resources>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -62,5 +62,6 @@
     <string name="checking_birthdays">Vérification…</string>
     <string name="manual_check">Vérification manuelle</string>
     <string name="add_contact">Ajouter un contact</string>
+    <string name="calendar_icon_desc">Icône de calendrier</string>
 </resources>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -62,5 +62,6 @@
     <string name="checking_birthdays">Verifica…</string>
     <string name="manual_check">Controllo manuale</string>
     <string name="add_contact">Aggiungi contatto</string>
+    <string name="calendar_icon_desc">Icona del calendario</string>
 </resources>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -62,5 +62,6 @@
     <string name="checking_birthdays">Verificando…</string>
     <string name="manual_check">Verificação manual</string>
     <string name="add_contact">Adicionar contato</string>
+    <string name="calendar_icon_desc">Ícone de calendário</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,5 +62,6 @@
     <string name="checking_birthdays">Checking…</string>
     <string name="manual_check">Manual Check</string>
     <string name="add_contact">Add Contact</string>
+    <string name="calendar_icon_desc">Calendar icon</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- replace custom floating buttons with Material buttons for manual check and adding contacts
- show calendar icon next to each birthday date in the list

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e5a3ace483339acb554c7d0aa2cb