### PR TITLE
Close notification after snooze and limit postpone options

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/framework/notification/WhatsAppBirthdayNotifier.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/framework/notification/WhatsAppBirthdayNotifier.kt
@@ -74,6 +74,7 @@ class WhatsAppBirthdayNotifier : BirthdayNotifier {
         val remoteInput = RemoteInput.Builder(SnoozeReceiver.KEY_SNOOZE_HOURS)
             .setLabel(context.getString(R.string.snooze_label))
             .setChoices(arrayOf("1", "2", "3", "4"))
+            .setAllowFreeFormInput(false)
             .build()
 
         val action = NotificationCompat.Action.Builder(

--- a/app/src/main/java/com/jlianes/birthdaynotifier/framework/receiver/SnoozeReceiver.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/framework/receiver/SnoozeReceiver.kt
@@ -1,11 +1,11 @@
 package com.jlianes.birthdaynotifier.framework.receiver
 
-import android.annotation.SuppressLint
 import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.RemoteInput
 
 /**
@@ -13,10 +13,10 @@ import androidx.core.app.RemoteInput
  */
 class SnoozeReceiver : BroadcastReceiver() {
 
-    @SuppressLint("ScheduleExactAlarm")
     override fun onReceive(context: Context, intent: Intent) {
         val results = RemoteInput.getResultsFromIntent(intent) ?: return
-        val hours = results.getCharSequence(KEY_SNOOZE_HOURS)?.toString()?.toIntOrNull() ?: return
+        val hours = results.getCharSequence(KEY_SNOOZE_HOURS)
+            ?.toString()?.toIntOrNull()?.takeIf { it in 1..4 } ?: return
         val name = intent.getStringExtra(EXTRA_NAME) ?: return
         val message = intent.getStringExtra(EXTRA_MESSAGE) ?: return
         val phone = intent.getStringExtra(EXTRA_PHONE) ?: return
@@ -34,14 +34,12 @@ class SnoozeReceiver : BroadcastReceiver() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        //val triggerAt = System.currentTimeMillis() + hours * 60 * 60 * 1000
-        val triggerAt = System.currentTimeMillis() + 15 * 1000  // 15 segundos
+        val triggerAt = System.currentTimeMillis() + hours * 60 * 60 * 1000
 
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAt, pending)
 
-        val notificationManager = androidx.core.app.NotificationManagerCompat.from(context)
-        notificationManager.cancelAll()
+        NotificationManagerCompat.from(context).cancel(name.hashCode())
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- Close birthday notifications after choosing Snooze
- Only allow choosing 1-4 hour delays for Snooze

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68950dbbc09c8333a6828256149bebb0