### PR TITLE
Simplify snooze to one hour

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/framework/notification/WhatsAppBirthdayNotifier.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/framework/notification/WhatsAppBirthdayNotifier.kt
@@ -9,7 +9,6 @@ import android.net.Uri
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.app.RemoteInput
 import com.jlianes.birthdaynotifier.domain.service.BirthdayNotifier
 import com.jlianes.birthdaynotifier.R
 import com.jlianes.birthdaynotifier.framework.receiver.SnoozeReceiver
@@ -71,17 +70,11 @@ class WhatsAppBirthdayNotifier : BirthdayNotifier {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
         )
 
-        val remoteInput = RemoteInput.Builder(SnoozeReceiver.KEY_SNOOZE_HOURS)
-            .setLabel(context.getString(R.string.snooze_label))
-            .setChoices(arrayOf("1", "2", "3", "4"))
-            .setAllowFreeFormInput(false)
-            .build()
-
         val action = NotificationCompat.Action.Builder(
             android.R.drawable.ic_menu_recent_history,
             context.getString(R.string.snooze_action),
             snoozePendingIntent
-        ).addRemoteInput(remoteInput).build()
+        ).build()
 
         val builder = NotificationCompat.Builder(context, "bday_channel")
             .setSmallIcon(android.R.drawable.ic_dialog_info)

--- a/app/src/main/java/com/jlianes/birthdaynotifier/framework/receiver/SnoozeReceiver.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/framework/receiver/SnoozeReceiver.kt
@@ -6,7 +6,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.app.RemoteInput
 
 /**
  * Receiver that schedules a delayed notification when the user selects a snooze option.
@@ -14,12 +13,11 @@ import androidx.core.app.RemoteInput
 class SnoozeReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
-        val results = RemoteInput.getResultsFromIntent(intent) ?: return
-        val hours = results.getCharSequence(KEY_SNOOZE_HOURS)
-            ?.toString()?.toIntOrNull()?.takeIf { it in 1..4 } ?: return
         val name = intent.getStringExtra(EXTRA_NAME) ?: return
         val message = intent.getStringExtra(EXTRA_MESSAGE) ?: return
         val phone = intent.getStringExtra(EXTRA_PHONE) ?: return
+
+        val hours = 1
 
         val resendIntent = Intent(context, SnoozedNotificationReceiver::class.java).apply {
             putExtra(EXTRA_NAME, name)
@@ -43,7 +41,6 @@ class SnoozeReceiver : BroadcastReceiver() {
     }
 
     companion object {
-        const val KEY_SNOOZE_HOURS = "EXTRA_SNOOZE_HOURS"
         const val EXTRA_NAME = "extra_name"
         const val EXTRA_MESSAGE = "extra_message"
         const val EXTRA_PHONE = "extra_phone"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -48,8 +48,7 @@
     <string name="default_message">Alles Gute zum Geburtstag, %1$s! 🎉🥳</string>
     <string name="notification_channel_name">Geburtstage</string>
     <string name="notification_title">Geburtstag von %1$s</string>
-    <string name="snooze_action">Verschieben</string>
-    <string name="snooze_label">Stunden (1-4)</string>
+    <string name="snooze_action">Verschieben 1 Stunde</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Daten löschen</string>
     <string name="delete_data_confirm">Alle Daten löschen?</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -48,8 +48,7 @@
     <string name="default_message">¡Felicidadeeeeees!!!!, %1$s! 🎉🥳</string>
     <string name="notification_channel_name">Cumpleaños</string>
     <string name="notification_title">Cumple de %1$s</string>
-    <string name="snooze_action">Posponer</string>
-    <string name="snooze_label">Horas (1-4)</string>
+    <string name="snooze_action">Posponer 1 hora</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Borrar datos</string>
     <string name="delete_data_confirm">¿Borrar todos los datos?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -48,8 +48,7 @@
     <string name="default_message">Joyeux anniversaire, %1$s ! 🎉🥳</string>
     <string name="notification_channel_name">Anniversaires</string>
     <string name="notification_title">Anniversaire de %1$s</string>
-    <string name="snooze_action">Reporter</string>
-    <string name="snooze_label">Heures (1-4)</string>
+    <string name="snooze_action">Reporter 1 heure</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Supprimer les données</string>
     <string name="delete_data_confirm">Supprimer toutes les données ?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -48,8 +48,7 @@
     <string name="default_message">Tanti auguri, %1$s! 🎉🥳</string>
     <string name="notification_channel_name">Compleanni</string>
     <string name="notification_title">Compleanno di %1$s</string>
-    <string name="snooze_action">Posticipa</string>
-    <string name="snooze_label">Ore (1-4)</string>
+    <string name="snooze_action">Posticipa 1 ora</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Elimina dati</string>
     <string name="delete_data_confirm">Eliminare tutti i dati?</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -48,8 +48,7 @@
     <string name="default_message">Parabéns, %1$s! 🎉🥳</string>
     <string name="notification_channel_name">Aniversários</string>
     <string name="notification_title">Aniversário de %1$s</string>
-    <string name="snooze_action">Adiar</string>
-    <string name="snooze_label">Horas (1-4)</string>
+    <string name="snooze_action">Adiar 1 hora</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Apagar dados</string>
     <string name="delete_data_confirm">Apagar todos os dados?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,8 +48,7 @@
     <string name="default_message">Happy birthday, %1$s! \uD83C\uDF89\uD83E\uDD73</string>
     <string name="notification_channel_name">Birthdays</string>
     <string name="notification_title">Birthday: %1$s</string>
-    <string name="snooze_action">Snooze</string>
-    <string name="snooze_label">Hours (1-4)</string>
+    <string name="snooze_action">Snooze 1 hour</string>
     <string name="default_web_client_id">793109226456-n35uqu21dd5s3i3ggn57807tvlkrgio9.apps.googleusercontent.com</string>
     <string name="delete_data">Delete data</string>
     <string name="delete_data_confirm">Delete all data?</string>


### PR DESCRIPTION
## Summary
- Remove hour selection and always snooze notifications for one hour
- Close entire notification when snoozed
- Translate new "Snooze 1 hour" action across all languages

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68951372ae8c8333aba52f8179fda28c