### PR TITLE
Add touch feedback for contact items

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayListActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayListActivity.kt
@@ -15,6 +15,7 @@ import android.provider.ContactsContract
 import android.telephony.TelephonyManager
 import android.text.InputType
 import android.view.View
+import android.view.HapticFeedbackConstants
 import android.widget.*
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
@@ -139,9 +140,17 @@ class BirthdayListActivity : BaseActivity() {
             applyFilters()
         }
 
-        binding.listView.setOnItemClickListener { _, _, pos, _ ->
-            val originalIndex = displayedIndices.getOrNull(pos) ?: pos
-            showEditDialog(originalIndex, helper.get(originalIndex))
+        binding.listView.setOnItemClickListener { _, view, pos, _ ->
+            view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+            view.animate()
+                .scaleX(0.95f)
+                .scaleY(0.95f)
+                .setDuration(100)
+                .withEndAction {
+                    view.animate().scaleX(1f).scaleY(1f).setDuration(100).start()
+                    val originalIndex = displayedIndices.getOrNull(pos) ?: pos
+                    showEditDialog(originalIndex, helper.get(originalIndex))
+                }.start()
         }
 
         binding.floatingButtons.setContent {

--- a/app/src/main/res/layout/item_birthday.xml
+++ b/app/src/main/res/layout/item_birthday.xml
@@ -5,8 +5,8 @@
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
     android:foreground="?attr/selectableItemBackground"
-    android:clickable="false"
-    android:focusable="false"
+    android:clickable="true"
+    android:focusable="true"
     app:cardElevation="0dp"
     app:cardCornerRadius="0dp"
     app:cardBackgroundColor="?attr/colorSurface">


### PR DESCRIPTION
## Summary
- enable ripple effect on contact cards
- animate list items and trigger haptic feedback when tapped

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895190cf5948333b1b44f1661c5415c