### PR TITLE
Fix soon birthday indicator when filtering names

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayAdapter.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayAdapter.kt
@@ -32,8 +32,10 @@ class BirthdayAdapter(context: Context, items: MutableList<JSONObject>) :
     }
     private var nextKey: Int = -1
 
-    fun refreshIndicators() {
-        val keys = (0 until count).mapNotNull { getItem(it)?.getString("date")?.let { d -> sortKey(d) } }
+    fun refreshIndicators(allItems: List<JSONObject>) {
+        val keys = allItems.mapNotNull { obj ->
+            obj.optString("date").takeIf { it.isNotBlank() }?.let { d -> sortKey(d) }
+        }
         nextKey = keys.filter { it > todayKey }.minOrNull() ?: keys.minOrNull() ?: -1
     }
 

--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayListActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/BirthdayListActivity.kt
@@ -117,7 +117,7 @@ class BirthdayListActivity : BaseActivity() {
         helper.load()
         adapter = BirthdayAdapter(this, helper.getAll().toMutableList())
         binding.listView.adapter = adapter
-        adapter.refreshIndicators()
+        adapter.refreshIndicators(helper.getAll())
 
         ArrayAdapter.createFromResource(
             this,
@@ -253,7 +253,7 @@ class BirthdayListActivity : BaseActivity() {
         displayedIndices = filtered.map { it.first }
         adapter.clear()
         adapter.addAll(filtered.map { it.second })
-        adapter.refreshIndicators()
+        adapter.refreshIndicators(baseList)
         adapter.notifyDataSetChanged()
     }
 


### PR DESCRIPTION
## Summary
- compute next upcoming birthday from the full list instead of filtered items
- refresh indicators with base list so "soon" tag stays consistent after applying name filters

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68952761aa3c8333b2207e8dcc70fbf4