### PR TITLE
Center birthday indicators in card layout

### DIFF
--- a/app/src/main/res/layout/item_birthday.xml
+++ b/app/src/main/res/layout/item_birthday.xml
@@ -11,26 +11,59 @@
     app:cardCornerRadius="0dp"
     app:cardBackgroundColor="?attr/colorSurface">
 
-    <LinearLayout
-        android:orientation="vertical"
-        android:padding="16dp"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
         <LinearLayout
+            android:orientation="vertical"
+            android:padding="16dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center_vertical">
+            android:layout_marginEnd="48dp">
 
             <TextView
                 android:id="@+id/textName"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
                 android:textStyle="bold"
                 android:textSize="18sp"
                 android:textColor="?attr/colorOnSurface" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <ImageView
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:src="@drawable/ic_calendar"
+                    android:tint="?attr/colorOnSurface"
+                    android:contentDescription="@string/calendar_icon_desc" />
+
+                <TextView
+                    android:id="@+id/textDate"
+                    android:layout_marginStart="4dp"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textSize="14sp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/textMessage"
+                android:textSize="14sp"
+                android:textColor="?attr/colorOnSurface"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+
+        <FrameLayout
+            android:layout_width="48dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="end|center_vertical">
 
             <ImageView
                 android:id="@+id/imageCake"
@@ -38,7 +71,8 @@
                 android:layout_height="24dp"
                 android:src="@drawable/ic_cake"
                 android:contentDescription="@string/cake_icon_desc"
-                android:visibility="gone" />
+                android:visibility="gone"
+                android:layout_gravity="center" />
 
             <TextView
                 android:id="@+id/textSoon"
@@ -47,36 +81,10 @@
                 android:text="@string/soon"
                 android:textSize="14sp"
                 android:textColor="?attr/colorPrimary"
-                android:visibility="gone" />
-        </LinearLayout>
+                android:visibility="gone"
+                android:gravity="center"
+                android:layout_gravity="center" />
+        </FrameLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center_vertical">
-
-            <ImageView
-                android:layout_width="16dp"
-                android:layout_height="16dp"
-                android:src="@drawable/ic_calendar"
-                android:tint="?attr/colorOnSurface"
-                android:contentDescription="@string/calendar_icon_desc" />
-
-            <TextView
-                android:id="@+id/textDate"
-                android:layout_marginStart="4dp"
-                android:textColor="?attr/colorOnSurface"
-                android:textSize="14sp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
-        </LinearLayout>
-
-        <TextView
-            android:id="@+id/textMessage"
-            android:textSize="14sp"
-            android:textColor="?attr/colorOnSurface"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-    </LinearLayout>
+    </FrameLayout>
 </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- Center the birthday cake icon or "Soon" label within a fixed container on each birthday card
- Reserve space so indicators are always aligned and centered vertically in the card

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895357910b883338b508f7791599fc5