### PR TITLE
Adjust right spacing for 'Soon' indicator

### DIFF
--- a/app/src/main/res/layout/item_birthday.xml
+++ b/app/src/main/res/layout/item_birthday.xml
@@ -20,7 +20,7 @@
             android:padding="16dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="48dp">
+            android:layout_marginEnd="64dp">
 
             <TextView
                 android:id="@+id/textName"
@@ -63,7 +63,8 @@
         <FrameLayout
             android:layout_width="48dp"
             android:layout_height="match_parent"
-            android:layout_gravity="end|center_vertical">
+            android:layout_gravity="end|center_vertical"
+            android:layout_marginEnd="16dp">
 
             <ImageView
                 android:id="@+id/imageCake"


### PR DESCRIPTION
## Summary
- Add right margin to birthday list icon container so the cake and `Soon...` labels are no longer stuck to the edge
- Increase end margin on list text container to avoid overlap

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689537724d1483339b2357f30cb541d3