### PR TITLE
Actualizar nombre e ícono según idioma y tema

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LocaleHelper.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LocaleHelper.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
 import android.os.LocaleList
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import java.util.Locale
 
 /**
@@ -47,5 +49,6 @@ object LocaleHelper {
     fun setLocale(context: Context, code: String) {
         val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
         prefs.edit().putString("language", code).apply()
+        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(code))
     }
 }

--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/SettingsActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/SettingsActivity.kt
@@ -2,7 +2,9 @@ package com.jlianes.birthdaynotifier.presentation
 
 import android.app.AlertDialog
 import android.app.TimePickerDialog
+import android.content.ComponentName
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.widget.EditText
 import android.widget.Toast
@@ -80,6 +82,7 @@ class SettingsActivity : BaseActivity() {
             .setTitle(R.string.language)
             .setSingleChoiceItems(languages, checked) { dialog, which ->
                 LocaleHelper.setLocale(this, codes[which])
+                updateLauncherIcon()
                 dialog.dismiss()
                 recreate()
             }
@@ -106,10 +109,30 @@ class SettingsActivity : BaseActivity() {
                     else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
                 }
                 AppCompatDelegate.setDefaultNightMode(mode)
+                updateLauncherIcon()
                 dialog.dismiss()
                 recreate()
             }
             .show()
+    }
+
+    /**
+     * Forces the launcher to reload the app's icon and label so that
+     * theme and language changes are reflected outside the app.
+     */
+    private fun updateLauncherIcon() {
+        val pm = packageManager
+        val component = ComponentName(this, LoginActivity::class.java)
+        pm.setComponentEnabledSetting(
+            component,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            PackageManager.DONT_KILL_APP
+        )
+        pm.setComponentEnabledSetting(
+            component,
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+            PackageManager.DONT_KILL_APP
+        )
     }
 
     private fun confirmDeleteData() {

--- a/app/src/main/res/drawable-night/ic_cake_main.xml
+++ b/app/src/main/res/drawable-night/ic_cake_main.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12 6c1.1 0 2-0.9 2-2 0-.38-.1-.73-.29-1.03L12 0l-1.71 2.97c-.19.3-.29.65-.29 1.03 0 1.1.9 2 2 2zM18 9h-5V7h-2v2H6c-1.66 0-3 1.34-3 3v9c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-9c0-1.66-1.34-3-3-3zm1 12H5v-7h14v7z"/>
+
+    <group
+        android:scaleX="0.3" android:scaleY="0.3"
+        android:translateX="8.5" android:translateY="14">
+        <path
+            android:fillColor="#FFFFFFFF"
+            android:pathData="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zM18 16v-5c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5S10.5 3.17 10.5 4v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/>
+    </group>
+</vector>
+


### PR DESCRIPTION
## Summary
- Forzar recarga del lanzador al cambiar idioma o tema
- Sincronizar idioma de la aplicación con AppCompatDelegate
- Agregar variante nocturna del icono principal

## Testing
- `gradle test` *(failed: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689733a5f3c08333a9b5674b01900719