### PR TITLE
Ensure launcher name updates with app language

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,12 @@ android {
     kotlinOptions {
         jvmTarget = '17'
     }
+
+    bundle {
+        language {
+            enableSplit = false
+        }
+    }
 }
 
     dependencies {

--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LocaleHelper.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LocaleHelper.kt
@@ -1,9 +1,12 @@
 package com.jlianes.birthdaynotifier.presentation
 
+import android.content.ComponentName
 import android.content.Context
+import android.content.pm.PackageManager
 import android.content.res.Configuration
-import android.os.Build
 import android.os.LocaleList
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import java.util.Locale
 
 /**
@@ -47,5 +50,22 @@ object LocaleHelper {
     fun setLocale(context: Context, code: String) {
         val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
         prefs.edit().putString("language", code).apply()
+
+        // Update application-wide locales for proper label rendering
+        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(code))
+
+        // Force launcher to reload the app label with the new language
+        val pm = context.packageManager
+        val component = ComponentName(context, LoginActivity::class.java)
+        pm.setComponentEnabledSetting(
+            component,
+            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            PackageManager.DONT_KILL_APP
+        )
+        pm.setComponentEnabledSetting(
+            component,
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+            PackageManager.DONT_KILL_APP
+        )
     }
 }


### PR DESCRIPTION
## Summary
- disable Play Store language splits so all translations ship with the app
- refresh launcher icon label after changing the in-app language

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68973ce7eefc8333b038bb591f312740