### PR TITLE
feat: add system language option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Birthday Notifier is an Android application written in Kotlin that reminds you o
 - **Firebase Auth & Firestore** – birthdays are stored per‑user in Firestore and synced across devices.
 - **Daily background check** – an `AlarmManager` trigger runs every day and after reboots to look for birthdays.
 - **WhatsApp integration** – notifications open WhatsApp with a prefilled message and allow snoozing for later.
-- **Multi language & theme** – the UI supports several languages and light/dark/system themes.
+- **Multi language & theme** – the UI supports several languages, can follow the system language, and offers light/dark/system themes.
 - **Contact import** – quickly add entries from the device contacts database.
 
 ## Project structure

--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LocaleHelper.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LocaleHelper.kt
@@ -2,7 +2,6 @@ package com.jlianes.birthdaynotifier.presentation
 
 import android.content.Context
 import android.content.res.Configuration
-import android.os.Build
 import android.os.LocaleList
 import java.util.Locale
 
@@ -18,8 +17,7 @@ object LocaleHelper {
      */
     fun getLanguage(context: Context): String {
         val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
-        val saved = prefs.getString("language", null)
-        return saved ?: Locale.getDefault().language
+        return prefs.getString("language", "system") ?: "system"
     }
 
     /**
@@ -29,8 +27,9 @@ object LocaleHelper {
      * @return Context A new context with the locale applied.
      */
     fun applyBaseContext(context: Context): Context {
-        val code = getLanguage(context)
-        val locale = Locale(code)
+        val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
+        val code = prefs.getString("language", "system")
+        val locale = if (code == "system") Locale.getDefault() else Locale(code!!)
         Locale.setDefault(locale)
 
         val config = Configuration(context.resources.configuration)

--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/SettingsActivity.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/SettingsActivity.kt
@@ -90,6 +90,7 @@ class SettingsActivity : BaseActivity() {
      */
     private fun showLanguageDialog() {
         val languages = arrayOf(
+            getString(R.string.system_default),
             getString(R.string.english),
             getString(R.string.spanish),
             getString(R.string.portuguese),
@@ -97,8 +98,9 @@ class SettingsActivity : BaseActivity() {
             getString(R.string.german),
             getString(R.string.french)
         )
-        val codes = arrayOf("en", "es", "pt", "it", "de", "fr")
-        val current = LocaleHelper.getLanguage(this)
+        val codes = arrayOf("system", "en", "es", "pt", "it", "de", "fr")
+        val prefs = getSharedPreferences("settings", MODE_PRIVATE)
+        val current = prefs.getString("language", "system")
         val checked = codes.indexOf(current).let { if (it >= 0) it else 0 }
         AlertDialog.Builder(this)
             .setTitle(R.string.language)


### PR DESCRIPTION
## Summary
- allow choosing a system language default
- document system language support

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975389cb988333bbdeb95b89dcc018