### PR TITLE
Fix locale handling for all languages

### DIFF
--- a/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LocaleHelper.kt
+++ b/app/src/main/java/com/jlianes/birthdaynotifier/presentation/LocaleHelper.kt
@@ -33,6 +33,9 @@ object LocaleHelper {
         Locale.setDefault(locale)
 
         val config = Configuration(context.resources.configuration)
+        // Ensure both locale and locale list are set so that all resources
+        // (including those expecting a single locale) resolve correctly.
+        config.setLocale(locale)
         config.setLocales(LocaleList(locale))
         return context.createConfigurationContext(config)
     }
@@ -45,6 +48,8 @@ object LocaleHelper {
      */
     fun setLocale(context: Context, code: String) {
         val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
-        prefs.edit().putString("language", code).apply()
+        // Use commit to persist the preference synchronously before a potential
+        // app restart, avoiding races where the new language might not be saved.
+        prefs.edit().putString("language", code).commit()
     }
 }


### PR DESCRIPTION
## Summary
- Ensure configuration sets both single locale and LocaleList
- Persist language preference synchronously to avoid losing selection on restart

## Testing
- `gradle test` *(fails: Could not determine the dependencies of task ':app:testDebugUnitTest'. Failed to install the following Android SDK packages as some licences have not been accepted.)*

------
https://chatgpt.com/codex/tasks/task_e_6897945dc8e88333bc91fa5f6c9f962a